### PR TITLE
Fix examples for vectorTranslate

### DIFF
--- a/src/gdal_utils.cpp
+++ b/src/gdal_utils.cpp
@@ -111,7 +111,7 @@ GDAL_ASYNCABLE_DEFINE(Utils::translate) {
  *
  * @example
  * const ds = gdal.open('input.geojson')
- * const out = gdal.vectorTranslate('/vsimem/temp.gpkg', [ '-of', 'GPKG' ], ds)
+ * const out = gdal.vectorTranslate('/vsimem/temp.gpkg', ds, [ '-of', 'GPKG' ])
  *
  * @throws {Error}
  * @method vectorTranslate
@@ -130,7 +130,7 @@ GDAL_ASYNCABLE_DEFINE(Utils::translate) {
  *
  * @example
  * const ds = gdal.open('input.geojson')
- * const out = gdal.vectorTranslate('/vsimem/temp.gpkg', [ '-of', 'GPKG' ], ds)
+ * const out = gdal.vectorTranslate('/vsimem/temp.gpkg', ds, [ '-of', 'GPKG' ])
  * @throws {Error}
  *
  * @method vectorTranslateAsync


### PR DESCRIPTION
The second and third arguments to vectorTranslate and vectorTranslateAsync were swapped