### PR TITLE
Add FieldDefn subtype

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -223,6 +223,12 @@ toc:
           - OFTTime
           - OFTWideString
           - OFTWideStringList
+      - name: Feature Field Sub-Types
+        children:
+          - OFSTNone
+          - OFSTBoolean
+          - OFSTInt16
+          - OFSTFloat32
       - name: Justification
         children:
           - OJLeft

--- a/lib/gdal.js
+++ b/lib/gdal.js
@@ -578,6 +578,17 @@ function fieldTypeFromValue(val) {
   throw new Error('Value cannot be converted into OGRFieldType')
 }
 
+function fieldSubtypeFromValue(val) {
+  const type = typeof val
+  if (type === 'boolean') {
+    return gdal.OFSTBoolean
+  } else if (val instanceof Array) {
+    return fieldSubtypeFromValue(val[0])
+  } else {
+    return gdal.OFSTNone
+  }
+}
+
 /**
  * Creates a LayerFields instance from an object of keys and values.
  *
@@ -611,7 +622,11 @@ gdal.LayerFields.prototype.fromObject = function (obj, approx_ok) {
   approx_ok = approx_ok || false
   Object.entries(obj).forEach(([ k, v ]) => {
     const type = fieldTypeFromValue(v)
+    const subtype = fieldSubtypeFromValue(v)
     const def = new gdal.FieldDefn(k, type)
+    if (subtype) {
+      def.subtype = subtype
+    }
     this.add(def, approx_ok)
   })
 }

--- a/src/gdal_field_defn.cpp
+++ b/src/gdal_field_defn.cpp
@@ -16,6 +16,7 @@ void FieldDefn::Initialize(Local<Object> target) {
 
   ATTR(lcons, "name", nameGetter, nameSetter);
   ATTR(lcons, "type", typeGetter, typeSetter);
+  ATTR(lcons, "subtype", subtypeGetter, subtypeSetter);
   ATTR(lcons, "justification", justificationGetter, justificationSetter);
   ATTR(lcons, "width", widthGetter, widthSetter);
   ATTR(lcons, "precision", precisionGetter, precisionSetter);
@@ -143,6 +144,25 @@ NAN_GETTER(FieldDefn::typeGetter) {
 }
 
 /**
+ * Data subtype (see {@link OFST|OFST constants}
+ *
+ * @kind member
+ * @name subtype
+ * @instance
+ * @memberof FieldDefn
+ * @type {string}
+ */
+NAN_GETTER(FieldDefn::subtypeGetter) {
+  FieldDefn *def = Nan::ObjectWrap::Unwrap<FieldDefn>(info.This());
+  OGRFieldSubType subtype = def->this_->GetSubType();
+  if (subtype == OFSTNone) {
+    info.GetReturnValue().Set(Nan::Undefined());
+    return;
+  }
+  info.GetReturnValue().Set(SafeString::New(getFieldSubTypeName(def->this_->GetSubType())));
+}
+
+/**
  * @kind member
  * @name ignored
  * @instance
@@ -223,6 +243,21 @@ NAN_SETTER(FieldDefn::typeSetter) {
     Nan::ThrowError("Unrecognized field type");
   } else {
     def->this_->SetType(OGRFieldType(type));
+  }
+}
+
+NAN_SETTER(FieldDefn::subtypeSetter) {
+  FieldDefn *def = Nan::ObjectWrap::Unwrap<FieldDefn>(info.This());
+  if (!value->IsString()) {
+    Nan::ThrowError("subtype must be a string");
+    return;
+  }
+  std::string name = *Nan::Utf8String(value);
+  int subtype = getFieldSubTypeByName(name.c_str());
+  if (subtype < 0) {
+    Nan::ThrowError("Unrecognized field subtype");
+  } else {
+    def->this_->SetSubType(OGRFieldSubType(subtype));
   }
 }
 

--- a/src/gdal_field_defn.hpp
+++ b/src/gdal_field_defn.hpp
@@ -27,6 +27,7 @@ class FieldDefn : public Nan::ObjectWrap {
 
   static NAN_GETTER(nameGetter);
   static NAN_GETTER(typeGetter);
+  static NAN_GETTER(subtypeGetter);
   static NAN_GETTER(justificationGetter);
   static NAN_GETTER(precisionGetter);
   static NAN_GETTER(widthGetter);
@@ -34,6 +35,7 @@ class FieldDefn : public Nan::ObjectWrap {
 
   static NAN_SETTER(nameSetter);
   static NAN_SETTER(typeSetter);
+  static NAN_SETTER(subtypeSetter);
   static NAN_SETTER(justificationSetter);
   static NAN_SETTER(precisionSetter);
   static NAN_SETTER(widthSetter);

--- a/src/node_gdal.cpp
+++ b/src/node_gdal.cpp
@@ -1544,6 +1544,43 @@ static void Init(Local<Object> target, Local<v8::Value>, void *) {
   Nan::Set(target, Nan::New("OFTDateTime").ToLocalChecked(), Nan::New(getFieldTypeName(OFTDateTime)).ToLocalChecked());
 
   /*
+   * Field sub-types
+   */
+
+  /**
+   * @final
+   * @constant
+   * @name OFSTNone
+   * @type {string}
+   */
+  Nan::Set(
+    target, Nan::New("OFSTNone").ToLocalChecked(), Nan::New(getFieldSubTypeName(OFSTNone)).ToLocalChecked());
+  /**
+   * @final
+   * @constant
+   * @name OFSTBoolean
+   * @type {string}
+   */
+  Nan::Set(
+    target, Nan::New("OFSTBoolean").ToLocalChecked(), Nan::New(getFieldSubTypeName(OFSTBoolean)).ToLocalChecked());
+  /**
+   * @final
+   * @constant
+   * @name OFSTInt16
+   * @type {string}
+   */
+  Nan::Set(
+    target, Nan::New("OFSTInt16").ToLocalChecked(), Nan::New(getFieldSubTypeName(OFSTInt16)).ToLocalChecked());
+  /**
+   * @final
+   * @constant
+   * @name OFSTFloat32
+   * @type {string}
+   */
+  Nan::Set(
+    target, Nan::New("OFSTFloat32").ToLocalChecked(), Nan::New(getFieldSubTypeName(OFSTFloat32)).ToLocalChecked());
+
+  /*
    * Resampling options that can be used with the gdal.reprojectImage() and gdal.RasterBandPixels.read methods.
    */
 

--- a/src/utils/field_types.hpp
+++ b/src/utils/field_types.hpp
@@ -35,4 +35,25 @@ inline int getFieldTypeByName(std::string name) {
   return -1;
 }
 
+// OFSTNone = 0, OFSTBoolean = 1, OFSTInt16 = 2, OFSTFloat32 = 3
+
+static const char *const FIELD_SUBTYPES[] = {
+  /* 0 */ "none",
+  /* 1 */ "boolean",
+  /* 2 */ "integer16",
+  /* 3 */ "float32"};
+
+inline const char *getFieldSubTypeName(OGRFieldSubType subtype) {
+  int i = static_cast<int>(subtype);
+  if (i < 0 || i > OFSTFloat32) { return "invalid"; }
+  return FIELD_SUBTYPES[i];
+}
+
+inline int getFieldSubTypeByName(std::string name) {
+  for (int i = 0; i <= OFSTFloat32; i++) {
+    if (name == FIELD_SUBTYPES[i]) return i;
+  }
+  return 0;
+}
+
 #endif


### PR DESCRIPTION
Hello,

In GDAL (OGR) some types have optional subtypes:
- Integer => Boolean, Integer16
- Real => Float32

The ability to know what subtype it is in a input layer, and to define the proper subtype in an output layer can be very useful (more compact datasets and true booleans in JavaScript or in a database).

I opened a PR as a first step. It will probably need some additional work.
I did not cast `integer(boolean)` to JS `boolean` not to introduce breaking changes.

Related to #37 