### PR TITLE
patch HDF5 .gitignore that is honoured by npm publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [3.8.0]
+## [3.8.1]
+
+### Changed
+ - Fix [mmomtchev/node-gdal-async#123](https://github.com/mmomtchev/node-gdal-async/issues/123), `H5version.h` is ignored by `.gitignore` and missing from the NPM tarball
+
+# [3.8.0] 2023-12-11
 
 ### Added
  - GDAL 3.8.0 with new `JSONFG`, `PMTiles` and `S102` drivers

--- a/deps/libhdf5/hdf5/.gitignore
+++ b/deps/libhdf5/hdf5/.gitignore
@@ -38,7 +38,6 @@ src/H5Epubgen.h
 src/H5Eterm.h
 src/H5config.h.in
 src/H5overflow.h
-src/H5version.h
 
 /.classpath
 /CMakeUserPresets.json

--- a/deps/libhdf5/patches/libhdf5_hdf5_.gitignore.diff
+++ b/deps/libhdf5/patches/libhdf5_hdf5_.gitignore.diff
@@ -1,0 +1,10 @@
+--- libhdf5/hdf5/.gitignore.orig	2023-12-11 20:44:08.607872973 +0100
++++ libhdf5/hdf5/.gitignore	2023-12-11 20:44:17.707798509 +0100
+@@ -38,7 +38,6 @@
+ src/H5Eterm.h
+ src/H5config.h.in
+ src/H5overflow.h
+-src/H5version.h
+ 
+ /.classpath
+ /CMakeUserPresets.json

--- a/deps/libhdf5/patches/libhdf5_hdf5_src_H5trace.c.diff
+++ b/deps/libhdf5/patches/libhdf5_hdf5_src_H5trace.c.diff
@@ -1,6 +1,6 @@
---- libhdf5/hdf5/src/H5trace.c.orig	2021-11-03 14:15:11.310888728 +0100
-+++ libhdf5/hdf5/src/H5trace.c	2021-11-03 14:16:10.918452952 +0100
-@@ -45,6 +45,10 @@
+--- libhdf5/hdf5/src/H5trace.c.orig	2023-10-28 21:26:51.000000000 +0200
++++ libhdf5/hdf5/src/H5trace.c	2023-12-11 13:46:28.461862891 +0100
+@@ -44,6 +44,10 @@
  #include "H5FDmpio.h"
  #endif /* H5_HAVE_PARALLEL */
  


### PR DESCRIPTION
Fixes #123