### PR TITLE
feat(fs): expose VSICurlClearCache as gdal.fs.clearCurlCache

### DIFF
--- a/src/gdal_fs.cpp
+++ b/src/gdal_fs.cpp
@@ -8,11 +8,25 @@ namespace node_gdal {
  * @namespace fs
  */
 
+/**
+ * Clears the /vsicurl/ and related network caches.
+ *
+ * @static
+ * @method clearCurlCache
+ * @memberof fs
+ */
+NAN_METHOD(VSI::clearCurlCache) {
+  Nan::HandleScope scope;
+  VSICurlClearCache();
+  info.GetReturnValue().Set(Nan::Undefined());
+}
+
 void VSI::Initialize(Local<Object> target) {
   Local<Object> fs = Nan::New<Object>();
   Nan::Set(target, Nan::New("fs").ToLocalChecked(), fs);
   Nan__SetAsyncableMethod(fs, "stat", stat);
   Nan__SetAsyncableMethod(fs, "readDir", readDir);
+  Nan::SetMethod(fs, "clearCurlCache", clearCurlCache);
 }
 
 /**

--- a/src/gdal_fs.hpp
+++ b/src/gdal_fs.hpp
@@ -28,6 +28,7 @@ namespace VSI {
 void Initialize(Local<Object> target);
 GDAL_ASYNCABLE_GLOBAL(stat);
 GDAL_ASYNCABLE_GLOBAL(readDir);
+static NAN_METHOD(clearCurlCache);
 
 } // namespace VSI
 } // namespace node_gdal

--- a/test/api_fs.test.ts
+++ b/test/api_fs.test.ts
@@ -52,4 +52,11 @@ describe('gdal.fs', () => {
       assert.isRejected(gdal.fs.readDirAsync(path.resolve(__dirname, 'data2')))
     )
   })
+  describe('clearCurlCache()', () => {
+    it('should be callable and not throw', () => {
+      assert.doesNotThrow(() => {
+        gdal.fs.clearCurlCache()
+      })
+    })
+  })
 })


### PR DESCRIPTION
This PR exposes the GDAL VSICurlClearCache() function.
#### Use Case:
Critical for users working with cloud VSI drivers (/vsis3/, /vsicurl/, etc.) who need to invalidate the network metadata cache without restarting the process.
#### Changes:
- Added gdal.fs.clearCurlCache() to src/gdal_fs.cpp
- Added JSDoc in .cpp for automated TypeScript/Documentation generation
- Added unit tests in test/api_fs.test.ts